### PR TITLE
Issue with spread_planets() on 0/360 boundaries, addition of standard unit tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,7 +136,8 @@ dmypy.json
 cache
 
 #Sean's Dev Log - no need to commit.
-*/sdevlog.md
+sdevlog.md
 #Sean's venv folders
 .astrenv
-
+#Ignore .vscode folder for integrated python debugger.
+.vscode/

--- a/natal_chart_gen/constants.py
+++ b/natal_chart_gen/constants.py
@@ -1,6 +1,6 @@
 IMAGES_URL = 'https://d1tswrzvc9aaiy.cloudfront.net/images/'
 
-IMG_DIR = "./assets/images"
+IMG_DIR = "./assets/images" 
 BG_IMG_DIR = "backgrounds"
 
 BG_IMG_FILES = {
@@ -14,10 +14,9 @@ BG_IMG_FILES = {
     "Natal_NFT_BGs-8.png":0.098,
     "Natal_NFT_BGs-9.png":0.098,
     "Natal_NFT_BGs-10.png":0.098,
-    "Natal_NFT_BGs-Rare_Red.png":0.02,
+    "Natal_NFT_BGs-Rare_Red.png":0.01,
     "Natal_NFT_BGs-Rare_Black.png":0.01,
 }
-
 
 SIGNS = ['Ari', 'Tau', 'Gem', 'Can', 'Leo', 'Vir', 'Lib', 'Sco', 'Sag', 'Cap', 'Aqu', 'Pis']
 

--- a/natal_chart_gen/prototype.py
+++ b/natal_chart_gen/prototype.py
@@ -1,7 +1,5 @@
 from datetime import datetime, timezone
 from io import BytesIO
-from random import uniform
-from sys import exit
 from numpy.random import choice
 import math
 import multiprocessing
@@ -207,7 +205,7 @@ def _generate(chart, load_image, bg_file=None):
 
 def random_asset(asset_dict):
     """
-        A helper function that selects a random asset filename, given a probability dictionary.
+        A helper function that selects a random asset filename, given a probability dictionary. Just wraps numpy.random.choice()
 
         Args:
             - asset_dict: A dictionary that has asset filenames for keys, mapping to probability values
@@ -216,37 +214,11 @@ def random_asset(asset_dict):
             - asset_name: A string name that was chosen from the dictionary.
 
         Exceptions:
-            - Exception: Generic exception thrown if probabilities of dictionary are not normalized. Will call sys.exit(2) if detected.
+            - ValueError: thrown by numpy if probabilities of dictionary are not normalized.
             
         Notes:
-            - This code assumes that dict.keys() and dict.values() always returns the same values in the same order.
-            if the dictionary is finalized, this should always be true for python 3.6+. See:
-            https://stackoverflow.com/questions/835092/python-dictionary-are-keys-and-values-always-the-same-order
-            - Users must take care to normalize their probability dictionaries. So the sum of all probs = 1.
-    """
-
-    #first, check to see that the dictionary values() normalize to 1.
-    """try:
-        psum = sum(asset_dict.values())
-        #This check is written this way, to deal with the possibility 
-        # of small round-off errors (machine arithmetic or human error).
-        if (psum < 0.9999 or psum > 1.0001):
-            raise Exception("Error: Asset dictionary probabilities not normalized. Aborting.")
-    except Exception as e:
-        print(e)
-        exit(2) """
-    # If we get here, then our dictionary was normalized OK. We may proceed.
-    #Let each probability be a small interval on (0,1). We randomly select from ~Uni(0,1), and
-    #subtract off interval lengths until we "land" in a particular interval zone. We just use the order of the dict keys, conviniently...
-    """rand_num = uniform(0,1)
-    chosen_item = ""
-    for item in asset_dict.keys():
-        prob = asset_dict[item]
-        rand_num -= prob
-        if (rand_num <= 0): #Landed in a zone. Choose the item associated with this zone!
-            chosen_item=item
-            break
-        return chosen_item
+            - This wrapper is pretty shallow - it just hides the more long-winded code seen in the return statement below.
+            - If the randomness functionality does not expand in the future, this function wrapper should be removed.
     """
     return choice(list(asset_dict.keys()), p=list(asset_dict.values()))
 

--- a/natal_chart_gen/test.py
+++ b/natal_chart_gen/test.py
@@ -7,8 +7,8 @@ random.seed(111)
 
 import swisseph as swe
 
-from prototype import Planet, Natal_Chart, _generate, random_asset
-from constants import PLANET_NAMES, SIGNS, BG_IMG_FILES, IMG_DIR
+from prototype import Planet, Natal_Chart, _generate
+from constants import PLANET_NAMES, SIGNS, IMG_DIR
 
 load_image = lambda filename: Image.open(os.path.join(IMG_DIR, filename))
 
@@ -52,33 +52,15 @@ def test_stelliums():
         positions += [random.uniform(0, 360) for _ in range(m)]
         return create_mock_natal_chart(positions)
 
-    for _ in range(10):
+    for _ in range(3):
         """
           generate conjunction/stellium with x planets,
           where x is randomly chosen between 2 and number of possible objects.
         """
-        chart = _generate_stellium(random.randint(2, len(Natal_Chart.required_objects)))
+        #random.randint(2, len(Natal_Chart.required_objects))
+        chart = _generate_stellium(2)
         im = _generate(chart, load_image)
         im.show()
-
-def test_random_asset():
-    """
-        In this test, we run random_asset X times, and tally the number of times we get each result.
-        The purpose here is to ensure that our share of trials for each item matches our probabilities.
-    """
-    binning_dict = {}
-    for name in BG_IMG_FILES.keys():
-        binning_dict[name] = 0
-    
-    print(binning_dict)
-
-    for _ in range(2000001):
-       binning_dict[random_asset(BG_IMG_FILES)] += 1
-
-    #Normalize our binning dict, converting to decimal values.
-    for item in BG_IMG_FILES.keys():
-        binning_dict[item] /= 2000000
-    print(binning_dict)
 
 def test_all_bg_images():
     """
@@ -148,9 +130,70 @@ def random_location():
     latitude = random.uniform(-90, 90)
     return longitude, latitude
 
+def stellium_test_run(int_list):
+    """
+        Given a list of 13 integer positions for each planet, generate a chart.
+
+        Args:
+            - intList: List of Integers that gives the angular position of the planets.
+
+        Notes: No error checking for list. If improper list length occurs,
+        code can silently fail in other places (like _generate()).            
+    """
+
+    test_chart = create_mock_natal_chart(int_list) #Need 13
+    for pname in test_chart.objects.keys():
+        print(test_chart.objects[pname])
+    im = _generate(test_chart, load_image)
+    im.show()
+
+def stellium_test_battery():
+    """
+        Wrapping function that runs a bunch of tests.
+        Speficially, we focus on stelliums (groups) near/on the ascendant boundary.
+    """
+
+    #Test1: Our first pathological test:
+    stellium_test_run([1,1,8,8,20,20,60,60,100,100,120,120,200])
+    #Test2: All planets just separated by 20 degrees, starting from 0
+    stellium_test_run([20,40,60,80,100,120,140,160,180,200,220,240,260]) 
+    #Test3: Pairs of two, spread out over the perimeter.
+    stellium_test_run([10,10,50,50,90,90,130,130,170,170,240,240,300])
+    #Test4: Pairs of two, with some pairs straddeling boundary.
+    stellium_test_run([5,5,90,90,130,130,170,170,240,240,300,355,355])
+    #Test5: Pairs of two, with a pair over boundary.
+    #Fails
+    stellium_test_run([0,45,90,90,130,130,170,170,240,240,300,345,359])
+    #Test6: Group of three, spread out.
+    stellium_test_run([40,40,40,120,120,120,200,200,200,250,250,250,320])
+    #Test6: Group of three, with pairs straddling boundary.
+    stellium_test_run([1,1,1,120,120,120,200,200,200,250,358,358,358])
+    #Test6: Group of three, with one group over boundary.
+    #Fails
+    stellium_test_run([0,1,120,120,120,200,200,200,200,340,340,340,359])
+    #Test7: One set of nine, the rest in another clump.
+    stellium_test_run([100,100,100,100,100,100,100,100,100,200,200,200,200])
+    #Test8: Group of nine, around the boundaries.
+    stellium_test_run([1,1,1,1,1,1,1,1,1,358,358,358,358])
+    #Test9: Group of nine, over the boundaries.
+    #Fails
+    stellium_test_run([0,0,1,1,1,250,250,250,250,358,359,359,359])
+    #Test: One clump of 6, another of 7, near each other.
+    stellium_test_run([100,100,100,100,100,100,110,110,110,110,110,110,110])
+    #Test: One clump of 6, another of 7, near each other, straddling boundary.
+    stellium_test_run([359,359,359,359,359,359,1,1,1,1,1,1,1])
+    #Test: One clump of 6, another of 7, over boundary.
+    #Fails
+    stellium_test_run([358,359,359,0,0,1,7,7,7,7,7,7,7])
+    #Test: Everything in one house
+    stellium_test_run([150,150,150,150,150,150,150,150,150,150,150,150,150])
+    #Test: Everything near the boundary
+    stellium_test_run([1,1,1,1,1,1,1,1,1,1,1,1,1])
+    #Test: Everything over the boundary
+    #Fails
+    stellium_test_run([357,357,358,358,359,359,0,0,0,1,1,1,2])
 
 if __name__ == "__main__":
     #test_stelliums()
-    #test_random_asset()
-    test_all_bg_images()
-
+    #test_all_bg_images()
+    stellium_test_battery()

--- a/sdevlog.md
+++ b/sdevlog.md
@@ -104,6 +104,89 @@ If you have already pushed your current branch to origin, just use:
 git pull
 ```
 
+#### Solving the clumping issues with n=2 Problem:
+
+I have looked over the code. Our call stack is:
+
+spread_planets()
+|
+|
+find_clumps()
+    clump_check()
+    pass()
+    merge()
+|
+|
+merge_clumps()
+|
+|
+split_clumps_by_sign()
+|
+|
+
+Firstly, can we generate arbitrary examples with n=2? How do we do this? Sasa has written a generate_stellium() function, with the following call stack:
+
+test_stellium()
+    -_generate_stellium()
+    |
+    |
+    create_mock_natal_chart()
+|
+|
+_generate_stellium()
+|
+|
+_generate()
+
+test_all_bg_images()
+|
+|
+random_chart()
+|
+|
+random_datetime()
+|
+|
+random_location()
+
+So we already have a stellium generator, that can generate pairs of Stelliums.
+
+When we print out the clumps, and run the algorithm, we don't see groupings of two listed in the clumps datastructure. Why?
+
+#### Problems with Boundary conditions when spreading planets:
+
+It turns out that we were not doing a deep copy when adding a planet to the end of the planet list, when running find_clumps(). So the spread issues near 0/360 were fixed.
+
+Likely though, there are other issues we need to deal with. Lets list some tests that we can run.
+
+1) All planets just separated by 20 degrees, starting from 0
+
+2) Pairs of Two: spread two pairs all over the place equidistant.
+
+3) Pairs of two test, spread out over the perimeter.
+
+4) Pairs of three, equidistant
+
+5) Pairs of three, loading the boundaries.
+
+6) 2 Pairs of 5 and 3, equidistant
+
+7) Same test, but pairs of 5 and three straddle the boundaries
+
+8) One pair of 9, the rest in another group.
+
+9) Same test, near the boundaries.
+
+10) Everything in one house
+
+11) Everything in one house, straddling boundary
+
+12) Everything in one house, in house 1 or 12 (spillover)
+
+#### Getting the VS Code Debugger to work:
+
+The debugger defaults to the root of the project - but we are running code in /natal_chart_gen/. I had to make a launch.json file and specify an absolute path to get things to work properly. VS Code generates the file for you!
+
 
 ## References:
 
@@ -117,4 +200,4 @@ git pull
 
 5) [Upload New Branch to Remote](https://stackoverflow.com/questions/2765421/how-do-i-push-a-new-local-branch-to-a-remote-git-repository-and-track-it-too)
 
-6) [Update your current branch from more recent origin](https://stackoverflow.com/questions/11278497/update-a-local-branch-with-the-changes-from-a-tracked-remote-branch)
+<!-- 6) [Update your current branch from more recent origin](https://stackoverflow.com/questions/11278497/update-a-local-branch-with-the-changes-from-a-tracked-remote-branch) -->


### PR DESCRIPTION
Hi Sasa,

Please see the following updates, below:

### n=2 issues near boundaries:

After playing with the code for a while, I was able to get some more insights into the issues you were having with the spread planets when n=2. I found that when a 2 planet stellium was near the 0/360 boundary, there were issues with the spreading of the groups. This specifically occurred in the following case:

Consider two planets, both at 1 degree. In the find clumps code, we add the first planet to the end of the planet lists, and run the following code:

```
    p0 = planets[0]
    p0.dpos += 360
    clumps1 = _pass(planets + [p0])
```
Because shallow copying is done here, we end up with the first and last element of the list having a dpos of 361 (instead of 1 and 361, respectively). Now when our spread test is run, in clumps_check():

```
abs(pn - p1) < theta * (n - 1)
```

we have abs(pn - p1) = 360 >> theta * (n-1). So our first planet was not being added to a clump. After adding deep copying, the following correction is seen below: 

![deepcopyeffect1](https://user-images.githubusercontent.com/22351082/226206674-3affaf71-37f0-4bcd-8469-5ed8f7201197.PNG)

![deepcopy2](https://user-images.githubusercontent.com/22351082/226206688-b3903f7a-bd71-4c9d-a251-af1e2818a04b.PNG)

### Unit Tests:

To get a better idea of how well the spread_planets+clumps() algorithms are running, I wrote a battery of test cases. These deal with stellium groups of various sizes, with three types of tests:

1) Regular tests, in which groups of size n are spread out over the natal chart.

2) A boundary case where two groups straddle either side of the 0/360 boundary.

3) Another boundary case where a group overlaps the 0/360 boundary.

After running all the tests, it seems that the algorithms have some issues with test (3) - overlapping the boundary. Some images of this are seen below:

Here Chiron is at 359, and the Ascendent at 0:

![test_pair_overlap_boundary](https://user-images.githubusercontent.com/22351082/226208224-ee9f0e1a-8473-429c-9963-c6ccd8df9783.PNG)

A similar situation with n=3 over boundary:

![3group_over_boundary](https://user-images.githubusercontent.com/22351082/226208315-cf6ea983-c8d3-4703-b18b-48fd1dc3bbff.PNG)

A more extreme case, with groups of size 6 and 7, close to one another, with an overlap:

![6and7overlap](https://user-images.githubusercontent.com/22351082/226208343-739dd4f4-150a-4f4c-8d55-bb0bbabdfc6b.PNG)

Granted, the n=6,7... case is quite extreme. The smaller cases are more likely to occur, and should be fixed.

### Other issues noted:

As you have probably observed, once in a while the spacing of the symbols is *slightly* off, as seen below.

![chiron_NN_overlap](https://user-images.githubusercontent.com/22351082/226208465-744b9a6b-af06-40ff-8834-52c1e29aec7a.PNG)

I think you have a github issue that already relates to this.

#### Some Next Steps:

1) Attempt to fix boundary issues for n=3,4....for extreme cases (n=6,8...12), is this something to worry about?

2) Work more on tests (to make them more robust, or automated) - possibly use a framework, or use image saving+hashing to automatically detect errors if the algorithms are tweaked in the future.

3) Work on the minor symbol misalignment issues - as per your Issue requests.
